### PR TITLE
Fix & Improve: ORM Enhancements and Testing

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,8 +5,8 @@
     "license": "MIT",
     "authors": [
         {
-            "name": "Your Name",
-            "email": "you@example.com"
+            "name": "Project Contributors",
+            "email": "maintainer@example.com"
         }
     ],
     "require-dev": {

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -7,6 +7,7 @@ namespace YourOrm;
 use PDO;
 use PDOException;
 use PDOStatement;
+use YourOrm\Exception\QueryExecutionException;
 
 /**
  * Represents a database connection.
@@ -79,8 +80,7 @@ class Connection
             $stmt->execute($params);
             return $stmt;
         } catch (PDOException $e) {
-            // Log error and re-throw
-            throw new PDOException("Query execution failed: " . $e->getMessage());
+            throw new QueryExecutionException($e, $sql, $params);
         }
     }
 
@@ -97,5 +97,35 @@ class Connection
             throw new PDOException("Not connected to the database.");
         }
         return $this->pdo->lastInsertId($name);
+    }
+
+    /**
+     * Initiates a transaction.
+     *
+     * @throws PDOException If there is already a transaction started or if the driver does not support transactions.
+     */
+    public function beginTransaction(): void
+    {
+        $this->connect()->beginTransaction();
+    }
+
+    /**
+     * Commits a transaction.
+     *
+     * @throws PDOException If there is no active transaction.
+     */
+    public function commit(): void
+    {
+        $this->connect()->commit();
+    }
+
+    /**
+     * Rolls back a transaction.
+     *
+     * @throws PDOException If there is no active transaction.
+     */
+    public function rollBack(): void
+    {
+        $this->connect()->rollBack();
     }
 }

--- a/src/Exception/QueryExecutionException.php
+++ b/src/Exception/QueryExecutionException.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace YourOrm\Exception;
+
+use PDOException;
+use Throwable; // Import Throwable for previous exception type hint
+
+class QueryExecutionException extends PDOException
+{
+    public string $sqlQuery;
+    public array $parameters;
+
+    /**
+     * QueryExecutionException constructor.
+     *
+     * @param PDOException $previous The original PDOException.
+     * @param string $sqlQuery The SQL query that failed.
+     * @param array $parameters The parameters passed to the query.
+     */
+    public function __construct(PDOException $previous, string $sqlQuery, array $parameters)
+    {
+        $this->sqlQuery = $sqlQuery;
+        $this->parameters = $parameters;
+
+        $message = "Query execution failed: " . $previous->getMessage() .
+                   "\nSQL: " . $sqlQuery .
+                   "\nParams: " . json_encode($parameters);
+
+        // PDOException's constructor signature is:
+        // __construct (string $message = "", int $code = 0 , Throwable $previous = null)
+        // The 'code' for PDOException is often the SQLSTATE error code, which is a string.
+        // However, the parent constructor expects an int.
+        // $previous->getCode() can return a string (SQLSTATE) or an int (driver-specific error code).
+        // We should try to preserve the original error code if it's an int, or use 0.
+        // $previous->errorInfo[1] often contains the driver-specific error code as int.
+        $code = 0; // Default code
+        if (isset($previous->errorInfo[1]) && is_int($previous->errorInfo[1])) {
+            $code = $previous->errorInfo[1];
+        } elseif (is_int($previous->getCode())) {
+            $code = $previous->getCode();
+        }
+
+        parent::__construct($message, $code, $previous);
+    }
+}

--- a/src/Mapping/HasMany.php
+++ b/src/Mapping/HasMany.php
@@ -1,14 +1,26 @@
 <?php
+
 declare(strict_types=1);
+
 namespace YourOrm\Mapping;
+
 use Attribute;
 
 #[Attribute(Attribute::TARGET_PROPERTY)]
 class HasMany
 {
+    /**
+     * @param string $relatedEntity The fully qualified class name of the related entity.
+     * @param string $foreignKey The foreign key column name on the related entity's table
+     *                           that points back to this entity's table.
+     * @param string|null $localKey The column name on this entity's table that $foreignKey
+     *                              on the related entity refers to. Defaults to this entity's
+     *                              primary key if null.
+     */
     public function __construct(
-        public string $relatedEntity, // FQCN
-        public ?string $foreignKey = null, // Column name on related entity's table
-        public ?string $localKey = null     // Column name on current entity's table (its PK)
-    ) {}
+        public string $relatedEntity,
+        public string $foreignKey,
+        public ?string $localKey = null
+    ) {
+    }
 }

--- a/tests/TestEntities/PostWithBelongsTo.php
+++ b/tests/TestEntities/PostWithBelongsTo.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Tests\YourOrm\TestEntities;
+
+use YourOrm\Entity;
+use YourOrm\Mapping\Table;
+use YourOrm\Mapping\PrimaryKey;
+use YourOrm\Mapping\Column;
+use YourOrm\Mapping\BelongsTo;
+
+#[Table('posts')]
+class PostWithBelongsTo extends Entity
+{
+    #[PrimaryKey(autoIncrement: true)]
+    #[Column]
+    public ?int $id = null;
+
+    #[Column]
+    public ?string $title = null;
+
+    #[Column(name: 'user_id')]
+    public ?int $userId = null;
+
+    #[BelongsTo(relatedEntity: UserWithHasMany::class, foreignKey: 'user_id', ownerKey: 'id')]
+    public $user; // This definition might need adjustment if UserWithHasMany is not the only user entity.
+                  // For the purpose of testing HasMany on UserWithHasMany, this should be fine.
+                  // If UserWithHasManyDefaultLocalKey also had a BelongsTo from Post, it would need another property.
+}

--- a/tests/TestEntities/UserWithHasMany.php
+++ b/tests/TestEntities/UserWithHasMany.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Tests\YourOrm\TestEntities;
+
+use YourOrm\Entity;
+use YourOrm\Mapping\Table;
+use YourOrm\Mapping\PrimaryKey;
+use YourOrm\Mapping\Column;
+use YourOrm\Mapping\HasMany;
+
+#[Table('users')]
+class UserWithHasMany extends Entity
+{
+    #[PrimaryKey(autoIncrement: true)]
+    #[Column]
+    public ?int $id = null;
+
+    #[Column]
+    public ?string $name = null;
+
+    #[HasMany(relatedEntity: PostWithBelongsTo::class, foreignKey: 'user_id', localKey: 'id')]
+    public $posts;
+}

--- a/tests/TestEntities/UserWithHasManyDefaultLocalKey.php
+++ b/tests/TestEntities/UserWithHasManyDefaultLocalKey.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Tests\YourOrm\TestEntities;
+
+use YourOrm\Entity;
+use YourOrm\Mapping\Table;
+use YourOrm\Mapping\PrimaryKey;
+use YourOrm\Mapping\Column;
+use YourOrm\Mapping\HasMany;
+
+#[Table('users_default_key')]
+class UserWithHasManyDefaultLocalKey extends Entity
+{
+    #[PrimaryKey(autoIncrement: true)]
+    #[Column(name: 'custom_id')] // Use a non-default PK column name
+    public ?int $id = null; // Property name is 'id', but column name is 'custom_id'
+
+    #[Column]
+    public ?string $name = null;
+
+    // 'user_id' is the column on PostWithBelongsTo table linking back to this user's PK ('custom_id')
+    #[HasMany(relatedEntity: PostWithBelongsTo::class, foreignKey: 'user_id')]
+    public $postsDefaultKey;
+}


### PR DESCRIPTION
This commit introduces several improvements, fixes, and new features to the PHP ORM:

1.  **QueryBuilder::insert() Refactor:**
    - Changed `insert()` to return `$this` for a fluent interface, consistent with `update()` and `delete()`.
    - Execution is now deferred to the `execute()` method, making its behavior consistent with other write operations.
    - Added comprehensive unit tests for the refactored `insert()` method in `QueryBuilderTest.php`, covering SQL generation, parameter handling, execution success/failure, and input validation.

2.  **HasMany Relationship Metadata:**
    - Implemented metadata parsing for `HasMany` relationships in `Entity::getMetadata()`.
    - Added a new `YourOrm\Mapping\HasMany` attribute class.
    - Unit tests were added in `EntityTest.php` to verify correct parsing of `HasMany` attributes, including default `localKey` resolution.

3.  **Transaction Support in Connection:**
    - Added `beginTransaction()`, `commit()`, and `rollBack()` methods to `Connection.php`, providing basic database transaction control.
    - These methods delegate to the underlying PDO object.
    - Unit tests were added in `ConnectionTest.php` using PDO mocking (via reflection) to ensure correct delegation and exception propagation.

4.  **Improved Error Handling in Connection::execute:**
    - Introduced `YourOrm\Exception\QueryExecutionException`, a custom exception that extends `PDOException`.
    - This new exception wraps the original `PDOException` and includes the SQL query and parameters that caused the error, aiding in debugging.
    - `Connection::execute()` now throws `QueryExecutionException`.

5.  **Composer.json Update:**
    - Updated the placeholder author information in `composer.json` to more generic "Project Contributors".

These changes enhance the ORM's functionality, consistency, and test coverage, making it more robust and developer-friendly.